### PR TITLE
bugfix: errors when an empty pipeline finishes with no data written

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function Pipeline (streams, opts) {
     this.splice.apply(this, [ 0, 0 ].concat(streams));
     
     this.once('finish', function () {
+        self._notEmpty();
         self._streams[0].end();
     });
 }


### PR DESCRIPTION
This is a corner case. It happens when an empty pipeline finishes before any data has been written.

```javascript
var pipeline = require('stream-splicer');
pipeline([]).end();
```

```
/Users/zoubin/usr/src/zoubin/stream-splicer/index.js:45
        self._streams[0].end();
                        ^
TypeError: Cannot read property 'end' of undefined
```