### PR TITLE
splice to delete only breaks the pipeline

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,21 +108,6 @@ Pipeline.prototype.unshift = function () {
 
 Pipeline.prototype.splice = function (start, removeLen) {
     var self = this;
-    var len = this._streams.length;
-    start = start < 0 ? len - start : start;
-    if (removeLen === undefined) removeLen = len - start;
-    removeLen = Math.max(0, Math.min(len - start, removeLen));
-    
-    for (var i = start; i < start + removeLen; i++) {
-        if (self._streams[i-1]) {
-            self._streams[i-1].unpipe(self._streams[i]);
-        }
-    }
-    if (self._streams[i-1] && self._streams[i]) {
-        self._streams[i-1].unpipe(self._streams[i]);
-    }
-    var end = i;
-    
     var reps = [], args = arguments;
     for (var j = 2; j < args.length; j++) (function (stream) {
         if (isArray(stream)) {
@@ -141,21 +126,57 @@ Pipeline.prototype.splice = function (start, removeLen) {
         });
         reps.push(stream);
     })(arguments[j]);
-    
-    for (var i = 0; i < reps.length - 1; i++) {
-        reps[i].pipe(reps[i+1]);
-    }
-    
-    if (reps.length && self._streams[end]) {
-        reps[reps.length-1].pipe(self._streams[end]);
-    }
-    if (reps[0] && self._streams[start-1]) {
-        self._streams[start-1].pipe(reps[0]);
-    }
-    
-    var sargs = [start,removeLen].concat(reps);
+
+    var flag = {};
+    var sargs = [start, removeLen, flag].concat(reps);
     var removed = self._streams.splice.apply(self._streams, sargs);
-    
+    start = indexof(self._streams, flag);
+    self._streams.splice(start, 1);
+
+    // `start` is the position where the insertion starts
+    // `end` is the position next to the place where the insertion ends
+    var end = start + reps.length;
+    var needInsert = end > start;
+
+    removeLen = removed.length;
+    if (removeLen) {
+        // break the removed pipeline
+        // after this, the original pipeline is broken if `self._streams[end]` exists
+        for (var i = 1; i < removeLen; i++) {
+            removed[i - 1].unpipe(removed[i]);
+        }
+        if (self._streams[start - 1]) {
+            self._streams[start - 1].unpipe(removed[0]);
+        }
+        if (self._streams[end]) {
+            removed[removeLen - 1].unpipe(self._streams[end]);
+        }
+    }
+
+    if (needInsert) {
+        // if nothing removed, we need to break the pipeline at `start` to insert
+        // after this, the pipeline will be fixed
+        if (!removeLen && self._streams[start - 1] && self._streams[end]) {
+            self._streams[start - 1].unpipe(self._streams[end]);
+        }
+        for (var i = 1; i < end - start; i++) {
+            reps[i - 1].pipe(reps[i]);
+        }
+        if (self._streams[start - 1]) {
+            self._streams[start - 1].pipe(reps[0]);
+        }
+        if (self._streams[end]) {
+            reps[end - start - 1].pipe(self._streams[end]);
+        }
+    }
+
+    if (removeLen && !needInsert) {
+        // streams removed and nothing inserted, the pipeline may be broken
+        if (self._streams[start - 1] && self._streams[end]) {
+            self._streams[start - 1].pipe(self._streams[end]);
+        }
+    }
+
     this.emit('_mutate');
     this.length = this._streams.length;
     return removed;

--- a/test/splice.js
+++ b/test/splice.js
@@ -56,3 +56,32 @@ test('splice', function (t) {
     stream.write('{"x":6}');
     stream.end();
 });
+
+test('splice to delete only', function (t) {
+    t.plan(1);
+    var a = { x: 1 };
+    var b = { x: 2 };
+    var c = { x: 3 };
+    var expected = [
+        { x: 3 },
+        { x: 4 },
+        { x: 5 }
+    ];
+
+    var stream = pipeline.obj([ add(), add(), add() ]);
+    stream.pipe(concat({ encoding: 'object' }, function (rows) {
+        t.same(rows, expected);
+    }));
+    stream.splice(1, 1);
+    stream.write(a);
+    stream.write(b);
+    stream.write(c);
+    stream.end();
+
+    function add() {
+        return through.obj(function (row, enc, next) {
+            row.x += 1;
+            next(null, row);
+        });
+    }
+});


### PR DESCRIPTION
If we use `.splice` to only delete some streams in the pipeline, without any new streams inserted, the pipeline will be leaved broken.

If the streams to delete lie at the start or end of the pipeline, we can use `.shift()` or `.pop()` to make it, otherwise, we have to use `.splice()`. But right now we have to use something like `.splice(1,1, through)` rather than `.splice(1,1)` to delete only. Example is described in https://github.com/substack/stream-splicer/issues/3

This pull-request fixes the pipeline if deletion occurs without insertion.
