### PR TITLE
Use Streams3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+  - "0.12"
+  - "iojs"
 before_install:
   - npm install -g npm@~1.4.6

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 var Duplex = require('readable-stream').Duplex;
 var PassThrough = require('readable-stream').PassThrough;
 var inherits = require('inherits');
-var isArray = require('isarray');
-var indexof = require('indexof');
 var wrap = require('readable-wrap');
 
 var nextTick = typeof setImmediate !== 'undefined'
@@ -13,7 +11,7 @@ module.exports = Pipeline;
 inherits(Pipeline, Duplex);
 
 module.exports.obj = function (streams, opts) {
-    if (!opts && !isArray(streams)) {
+    if (!opts && !Array.isArray(streams)) {
         opts = streams;
         streams = [];
     }
@@ -25,7 +23,7 @@ module.exports.obj = function (streams, opts) {
 
 function Pipeline (streams, opts) {
     if (!(this instanceof Pipeline)) return new Pipeline(streams, opts);
-    if (!opts && !isArray(streams)) {
+    if (!opts && !Array.isArray(streams)) {
         opts = streams;
         streams = [];
     }
@@ -77,7 +75,7 @@ Pipeline.prototype._notEmpty = function () {
     if (this._streams.length > 0) return;
     var stream = new PassThrough(this._options);
     stream.once('end', function () {
-        var ix = indexof(self._streams, stream);
+        var ix = self._streams.indexOf(stream);
         if (ix >= 0 && ix === self._streams.length - 1) {
             Duplex.prototype.push.call(self, null);
         }
@@ -124,7 +122,7 @@ Pipeline.prototype.splice = function (start, removeLen) {
     
     var reps = [], args = arguments;
     for (var j = 2; j < args.length; j++) (function (stream) {
-        if (isArray(stream)) {
+        if (Array.isArray(stream)) {
             stream = new Pipeline(stream, self._options);
         }
         stream.on('error', function (err) {
@@ -133,7 +131,7 @@ Pipeline.prototype.splice = function (start, removeLen) {
         });
         stream = self._wrapStream(stream);
         stream.once('end', function () {
-            var ix = indexof(self._streams, stream);
+            var ix = self._streams.indexOf(stream);
             if (ix >= 0 && ix === self._streams.length - 1) {
                 Duplex.prototype.push.call(self, null);
             }
@@ -178,7 +176,7 @@ Pipeline.prototype.get = function () {
 };
 
 Pipeline.prototype.indexOf = function (stream) {
-    return indexof(this._streams, stream);
+    return this._streams.indexOf(stream);
 };
 
 Pipeline.prototype._wrapStream = function (stream) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var Duplex = require('readable-stream').Duplex;
-var Readable = require('readable-stream').Readable;
-var Pass = require('readable-stream').PassThrough;
+var PassThrough = require('readable-stream').PassThrough;
 var inherits = require('inherits');
 var isArray = require('isarray');
 var indexof = require('indexof');
@@ -76,7 +75,7 @@ Pipeline.prototype._write = function (buf, enc, next) {
 Pipeline.prototype._notEmpty = function () {
     var self = this;
     if (this._streams.length > 0) return;
-    var stream = new Pass(this._options);
+    var stream = new PassThrough(this._options);
     stream.once('end', function () {
         var ix = indexof(self._streams, stream);
         if (ix >= 0 && ix === self._streams.length - 1) {

--- a/package.json
+++ b/package.json
@@ -5,15 +5,14 @@
   "main": "index.js",
   "dependencies": {
     "inherits": "^2.0.1",
-    "readable-stream": "^1.1.13-1",
-    "readable-wrap": "^1.0.0",
-    "through2": "^1.0.0"
+    "readable-stream": "^2.0.2"
   },
   "devDependencies": {
-    "tape": "^2.12.1",
-    "JSONStream": "~0.8.2",
+    "JSONStream": "^1.0.4",
     "concat-stream": "^1.4.6",
-    "split": "~0.3.0"
+    "split": "^1.0.0",
+    "tape": "^4.2.0",
+    "through2": "^2.0.0"
   },
   "scripts": {
     "test": "tape test/*.js"

--- a/package.json
+++ b/package.json
@@ -5,11 +5,9 @@
   "main": "index.js",
   "dependencies": {
     "inherits": "^2.0.1",
-    "isarray": "~0.0.1",
     "readable-stream": "^1.1.13-1",
     "readable-wrap": "^1.0.0",
-    "through2": "^1.0.0",
-    "indexof": "0.0.1"
+    "through2": "^1.0.0"
   },
   "devDependencies": {
     "tape": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -33,23 +33,5 @@
     "email": "mail@substack.net",
     "url": "http://substack.net"
   },
-  "license": "MIT",
-  "testling": {
-    "files": "test/*.js",
-    "browsers": [
-      "ie/8..latest",
-      "firefox/15",
-      "firefox/latest",
-      "firefox/nightly",
-      "chrome/15",
-      "chrome/latest",
-      "chrome/canary",
-      "opera/12..latest",
-      "opera/next",
-      "safari/5.1..latest",
-      "ipad/6.0..latest",
-      "iphone/6.0..latest",
-      "android-browser/4.2..latest"
-    ]
-  }
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "tape": "^2.12.1",
     "JSONStream": "~0.8.2",
     "concat-stream": "^1.4.6",
-    "split": "~0.3.0",
-    "object-keys": "~0.5.1"
+    "split": "~0.3.0"
   },
   "scripts": {
     "test": "tape test/*.js"

--- a/readme.markdown
+++ b/readme.markdown
@@ -6,9 +6,7 @@ This module is similar to
 [stream-combiner](https://npmjs.org/package/stream-combiner),
 but with a pipeline configuration that can be changed at runtime.
 
-[![testling badge](https://ci.testling.com/substack/stream-splicer.png)](https://ci.testling.com/substack/stream-splicer)
-
-[![build status](https://secure.travis-ci.org/substack/stream-splicer.png)](http://travis-ci.org/substack/stream-splicer)
+[![build status](https://travis-ci.org/substack/stream-splicer.png?branch=master)](http://travis-ci.org/substack/stream-splicer)
 
 # example
 

--- a/test/nested.js
+++ b/test/nested.js
@@ -1,6 +1,5 @@
 var pipeline = require('../');
 var through = require('through2');
-var stringify = require('JSONStream').stringify;
 var split = require('split');
 var concat = require('concat-stream');
 var test = require('tape');

--- a/test/nested_middle.js
+++ b/test/nested_middle.js
@@ -1,6 +1,5 @@
 var pipeline = require('../');
 var through = require('through2');
-var stringify = require('JSONStream').stringify;
 var split = require('split');
 var concat = require('concat-stream');
 var test = require('tape');

--- a/test/push.js
+++ b/test/push.js
@@ -1,7 +1,6 @@
 var pipeline = require('../');
 var through = require('through2');
 var split = require('split');
-var concat = require('concat-stream');
 var test = require('tape');
 
 test('push', function (t) {

--- a/test/shift.js
+++ b/test/shift.js
@@ -1,7 +1,5 @@
 var pipeline = require('../');
 var through = require('through2');
-var split = require('split');
-var concat = require('concat-stream');
 var test = require('tape');
 
 test('shift', function (t) {

--- a/test/unshift.js
+++ b/test/unshift.js
@@ -1,7 +1,5 @@
 var pipeline = require('../');
 var through = require('through2');
-var split = require('split');
-var concat = require('concat-stream');
 var test = require('tape');
 
 test('unshift', function (t) {


### PR DESCRIPTION
* Remove unused vars and deps
* Remove old compat deps "isarray" and "indexof"
* Remove testling and add node 0.12 + iojs to travis
* Use streams3
  * Update to readable-stream@^2.0.2
  * Remove "readable-wrap" since it isn't needed anymore because the [issue] [1] it aimed to fix is now part of [streams3] [2].
  * Move "through2" to devDeps
  * Update devDeps

[1]: joyent/node#7758
[2]: https://github.com/nodejs/readable-stream/blob/v2.0.2/lib/_stream_readable.js#L812-L816